### PR TITLE
adding dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2 
+updates:
+  - package-ecosystem: 'npm'
+    directory: '/' 
+    schedule:
+      interval: 'weekly'


### PR DESCRIPTION
dependabot will need to be enabled in the repo settings for this to work.
This will do weekly checks for website packages and put up PR for the ones that need to be updated.