### PR TITLE
If the author's url does not start with http(s) then append https

### DIFF
--- a/components/pages/blog/post/AboutAuthor.jsx
+++ b/components/pages/blog/post/AboutAuthor.jsx
@@ -72,6 +72,11 @@ const AboutAuthorWrap = styled.div`
 const AboutAuthor = ({ author }) => {
   if (!author) return;
 
+  // If the author's url does not start with http(s) then append https
+  if (!author.blog.startsWith('http')) {
+    author.blog = `https://${author.blog}`;
+  }
+  
   return (
     <AboutAuthorWrap className="about-author component">
       <div className="component-content">


### PR DESCRIPTION
If the author's url does not start with http(s) then append https This fixes https://www.codeedit.app/blog/2024/02/generic-fuzzy-search-algorithm

### Description

If the author's url does not start with http(s) then append https 
This fixes https://www.codeedit.app/blog/2024/02/generic-fuzzy-search-algorithm
The current url is `https://www.codeedit.app/blog/2024/02/activecoding.de.cool`
After this PR the url is `https://activecoding.de.cool`

### Related Issues

None.

<!--- Add things that are not yet implemented above -->

- [x] I read and understood the [contributing guide](https://github.com/CodeEditApp/CodeEdit/blob/main/CONTRIBUTING.md) as well as the [code of conduct](https://github.com/CodeEditApp/CodeEdit/blob/main/CODE_OF_CONDUCT.md)
- [x] The issues this PR addresses are related to each other
- [x] My changes generate no new warnings
- [x] My code builds and runs on my machine
- [x] My changes are all related to the related issue above
- [x] I documented my code

### Screenshots

N/A